### PR TITLE
Update for use with Docker Cloud (ex. Tutum)

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -28,7 +28,7 @@ do
       service_url=${!env_var}
 
 cat <<EOF >> /tmp/cron.tmp
-${schedule} curl -X POST -H "Authorization: $TUTUM_AUTH" -H "Accept: application/json" ${service_url}start/
+${schedule} curl -X POST -H "Authorization: $DOCKERCLOUD_AUTH" -H "Accept: application/json" ${service_url}start/
 EOF
     done
 


### PR DESCRIPTION
Use DOCKERCLOUD_AUTH instead of TUTUM_AUTH. At this time, Docker Cloud still seems to set the <SERVICE_NAME>_TUTUM_API_URL environment variables, so I did not change this one yet.
